### PR TITLE
Clarifications to Jira extension docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The `jira.apiToken`, `jira.url`, and `jira.username` values should be added as t
 }
 ```
 
-Follow [these instructions](https://confluence.atlassian.com/cloud/api-tokens-938839638.html) to generate a Jira Cloud API token. The `jira.url` should be the base URL for your Jira instance, eg `https://example.atlassian.net/`. The `jira.username` is the email address you use to authenticate with Jira.
+Follow [Atlassian's instructions on API tokens](https://confluence.atlassian.com/cloud/api-tokens-938839638.html) to generate a Jira Cloud API token. The `jira.url` should be the base URL for your Jira instance, e.g. `https://example.atlassian.net/`. The `jira.username` is the email address you use to authenticate with Jira.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jira extension for Sourcegraph
 
-A [Sourcegraph extension](https://docs.sourcegraph.com/extensions) that enhances GitHub with better [Atlassian Jira](https://www.atlassian.com/software/jira) integration.
+A [Sourcegraph extension](https://docs.sourcegraph.com/extensions) that enhances GitHub with better [Jira](https://www.atlassian.com/software/jira) integration.
 
 [**🗃️ Source code**](https://github.com/sourcegraph/sourcegraph-jira)
 
@@ -15,10 +15,27 @@ This extension currently only works on GitHub (and GitHub Enterprise), not on So
 1. Install the [Sourcegraph browser extension](https://docs.sourcegraph.com/integration/browser_extension).
    - In the Sourcegraph browser extension options menu, click the gear (⚙️) and enable **Experimental link previews** and **Experimental text field completion**.
 1. [Enable the Jira extension](https://sourcegraph.com/extensions/sourcegraph/jira) in the Sourcegraph extension registry (requires sign-in to Sourcegraph).
-1. Configure the Jira extension in [Sourcegraph user settings](https://sourcegraph.com/user/settings): `jira.apiToken`, `jira.url`, and `jira.username`.
+1. Configure the Jira extension in [Sourcegraph user settings](https://sourcegraph.com/user/settings): `jira.apiToken`, `jira.url`, and `jira.username`. See info below.
 1. Visit any text area, comment, PR, or issue on GitHub and try the [features](#features) below.
 
 If using GitHub Enterprise, right-click on the Sourcegraph browser extension icon when you're on a GitHub Enterprise page and select **Enable Sourcegraph on this domain**.
+
+## Configuring user settings
+
+The `jira.apiToken`, `jira.url`, and `jira.username` values should be added as top-level strings in the user settings (outside of the `extensions` object), eg:
+
+```
+{
+	"extensions": {
+		"sourcegraph/jira": true
+	},
+	"jira.apiToken": "token",
+	"jira.url": "https://sourcegraph.atlassian.net",
+	"jira.username": "emily@sourcegraph.com"
+}
+```
+
+Follow [these instructions](https://confluence.atlassian.com/cloud/api-tokens-938839638.html) to generate a Jira Cloud API token. The `jira.url` should be the base URL for your Jira instance, eg `https://sourcegraph.atlassian.net/`. The `jira.username` is the email address you use to authenticate with Jira.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If using GitHub Enterprise, right-click on the Sourcegraph browser extension ico
 
 ## Configuring user settings
 
-The `jira.apiToken`, `jira.url`, and `jira.username` values should be added as top-level strings in the user settings (outside of the `extensions` object), eg:
+The `jira.apiToken`, `jira.url`, and `jira.username` values should be added as top-level keys in the user settings (outside of the `extensions` object), eg:
 
 ```
 {

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ The `jira.apiToken`, `jira.url`, and `jira.username` values should be added as t
 		"sourcegraph/jira": true
 	},
 	"jira.apiToken": "token",
-	"jira.url": "https://sourcegraph.atlassian.net",
-	"jira.username": "emily@sourcegraph.com"
+	"jira.url": "https://example.atlassian.net",
+	"jira.username": "user@example.com"
 }
 ```
 
-Follow [these instructions](https://confluence.atlassian.com/cloud/api-tokens-938839638.html) to generate a Jira Cloud API token. The `jira.url` should be the base URL for your Jira instance, eg `https://sourcegraph.atlassian.net/`. The `jira.username` is the email address you use to authenticate with Jira.
+Follow [these instructions](https://confluence.atlassian.com/cloud/api-tokens-938839638.html) to generate a Jira Cloud API token. The `jira.url` should be the base URL for your Jira instance, eg `https://example.atlassian.net/`. The `jira.username` is the email address you use to authenticate with Jira.
 
 ## Features
 


### PR DESCRIPTION
- Clarifying where to add settings. 
- Removing "Atlassian Jira" in favor of "Jira" (generally the suite is just referred to as Jira, sometimes Jira Software, Jira Service Desk, etc.). 
- Added info on where to generate a Jira cloud API key because it's not intuitive.
- Clarified what the URL and username should be.

I didn't update this to say it only works with Jira Cloud, but if that's the case we should be explicit (unless I just missed it in the text). API keys are I think Cloud-only (the token situation on Server is a little different) which is why I ask.